### PR TITLE
refactor: implement naming migration system and improve memory management

### DIFF
--- a/Mod.cs
+++ b/Mod.cs
@@ -26,6 +26,7 @@ using Game.Modding;
 using Game.SceneFlow;
 using StationNaming.Setting;
 using StationNaming.System;
+using StationNaming.System.Cleanup;
 
 namespace StationNaming
 {
@@ -69,6 +70,7 @@ namespace StationNaming
             updateSystem.UpdateAt<GeneralBuildingNamingSystem>(SystemUpdatePhase.UIUpdate);
             updateSystem.UpdateBefore<AutoUpdateNamingSystem>(SystemUpdatePhase.UIUpdate);
             updateSystem.UpdateAfter<AutoNamingSystem>(SystemUpdatePhase.UIUpdate);
+            updateSystem.UpdateAt<CleanupSystem>(SystemUpdatePhase.PostSimulation);
         }
 
         public void OnDispose()

--- a/Mod.cs
+++ b/Mod.cs
@@ -70,7 +70,7 @@ namespace StationNaming
             updateSystem.UpdateAt<GeneralBuildingNamingSystem>(SystemUpdatePhase.UIUpdate);
             updateSystem.UpdateBefore<AutoUpdateNamingSystem>(SystemUpdatePhase.UIUpdate);
             updateSystem.UpdateAfter<AutoNamingSystem>(SystemUpdatePhase.UIUpdate);
-            updateSystem.UpdateAt<CleanupSetupSystem>(SystemUpdatePhase.LoadSimulation);
+            updateSystem.UpdateAfter<CleanupSetupSystem>(SystemUpdatePhase.GameSimulation);
             updateSystem.UpdateAfter<CleanupSystem>(SystemUpdatePhase.ModificationEnd);
         }
 

--- a/Mod.cs
+++ b/Mod.cs
@@ -70,7 +70,7 @@ namespace StationNaming
             updateSystem.UpdateAt<GeneralBuildingNamingSystem>(SystemUpdatePhase.UIUpdate);
             updateSystem.UpdateBefore<AutoUpdateNamingSystem>(SystemUpdatePhase.UIUpdate);
             updateSystem.UpdateAfter<AutoNamingSystem>(SystemUpdatePhase.UIUpdate);
-            updateSystem.UpdateAt<CleanupSystem>(SystemUpdatePhase.PostSimulation);
+            updateSystem.UpdateAfter<CleanupSystem>(SystemUpdatePhase.ModificationEnd);
         }
 
         public void OnDispose()

--- a/Mod.cs
+++ b/Mod.cs
@@ -70,6 +70,7 @@ namespace StationNaming
             updateSystem.UpdateAt<GeneralBuildingNamingSystem>(SystemUpdatePhase.UIUpdate);
             updateSystem.UpdateBefore<AutoUpdateNamingSystem>(SystemUpdatePhase.UIUpdate);
             updateSystem.UpdateAfter<AutoNamingSystem>(SystemUpdatePhase.UIUpdate);
+            updateSystem.UpdateAt<CleanupSetupSystem>(SystemUpdatePhase.LoadSimulation);
             updateSystem.UpdateAfter<CleanupSystem>(SystemUpdatePhase.ModificationEnd);
         }
 

--- a/Setting/NameFormatter.cs
+++ b/Setting/NameFormatter.cs
@@ -32,7 +32,7 @@ namespace StationNaming.Setting
 {
     public class NameFormatter
     {
-        private readonly EntityManager _entityManager;
+        private EntityManager _entityManager;
         private readonly NameSystem _nameSystem;
         private readonly PrefabSystem _prefabSystem;
 
@@ -84,6 +84,7 @@ namespace StationNaming.Setting
                 {
                     return;
                 }
+
                 var format = Options.SourceFormats[refer.Source];
                 var name = refer.GetName(_entityManager, _nameSystem);
                 var isNextIntersection = next?.Source == NameSource.Intersection;

--- a/System/AutoNamingSystem.cs
+++ b/System/AutoNamingSystem.cs
@@ -62,33 +62,15 @@ namespace StationNaming.System
                 EntityManager.RemoveComponent<ToAutoNaming>(entity);
                 EntityManager.RemoveComponent<Selected>(entity);
 
-                var entityNaming = new ManualSelectNaming(candidate);
+                var entityNaming = new ManualSelectNaming(candidate.DeepCopy());
                 var association = new NamingAssociation(entity);
 
                 EntityManager.AddComponentData(entity, entityNaming);
+                SystemUtils.AddComponent<ManualSelectNamingTag>(EntityManager, entity);
                 AddAssociations(association, candidate.Refers);
 
-                ReleaseCandidates(candidates, candidate);
+                EntityManager.RemoveComponent<NameCandidateTag>(entity);
             }
-        }
-
-
-        private static void ReleaseCandidates(
-            DynamicBuffer<NameCandidate> candidates,
-            NameCandidate chosen
-        )
-        {
-            for (var i = 0; i < candidates.Length; i++)
-            {
-                var candidate = candidates[i];
-                if (candidate.Equals(chosen))
-                {
-                    continue;
-                }
-                NameCandidate.Release(ref candidate);
-            }
-
-            candidates.Clear();
         }
 
         private void AddAssociations(

--- a/System/AutoNamingSystem.cs
+++ b/System/AutoNamingSystem.cs
@@ -68,8 +68,27 @@ namespace StationNaming.System
                 EntityManager.AddComponentData(entity, entityNaming);
                 AddAssociations(association, candidate.Refers);
 
-                candidates.Clear();
+                ReleaseCandidates(candidates, candidate);
             }
+        }
+
+
+        private static void ReleaseCandidates(
+            DynamicBuffer<NameCandidate> candidates,
+            NameCandidate chosen
+        )
+        {
+            for (var i = 0; i < candidates.Length; i++)
+            {
+                var candidate = candidates[i];
+                if (candidate.Equals(chosen))
+                {
+                    continue;
+                }
+                NameCandidate.Release(ref candidate);
+            }
+
+            candidates.Clear();
         }
 
         private void AddAssociations(

--- a/System/AutoUpdateNamingSystem.cs
+++ b/System/AutoUpdateNamingSystem.cs
@@ -100,10 +100,9 @@ namespace StationNaming.System
                 copy.Name = updatedName;
 
                 valid.Add(naming);
-                EntityManager.AddComponentData(
-                    target,
-                    new ManualSelectNaming(copy)
-                );
+                selectNaming.SelectedName = copy;
+
+                EntityManager.SetComponentData(target, selectNaming);
 
                 rawNameCandidate.Release();
 

--- a/System/AutoUpdateNamingSystem.cs
+++ b/System/AutoUpdateNamingSystem.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 RollW
+// Copyright (c) 2024 RollW
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/System/AutoUpdateNamingSystem.cs
+++ b/System/AutoUpdateNamingSystem.cs
@@ -68,7 +68,7 @@ namespace StationNaming.System
         private void CheckAndUpdate(Entity entity)
         {
             var namingAssociations = EntityManager.GetBuffer<NamingAssociation>(entity);
-            List<NamingAssociation> valid = new List<NamingAssociation>();
+            var valid = new List<NamingAssociation>();
 
             foreach (var naming in namingAssociations)
             {
@@ -89,13 +89,14 @@ namespace StationNaming.System
                 {
                     // it probably means user has changed the name,
                     // we should not update it
+                    selectNaming.SelectedName.Release();
                     EntityManager.RemoveComponent<ManualSelectNaming>(target);
                     continue;
                 }
 
                 var updatedName = GetUpdatedName(selectNaming, target);
 
-                var copy = rawNameCandidate;
+                var copy = rawNameCandidate.DeepCopy();
                 copy.Name = updatedName;
 
                 valid.Add(naming);
@@ -103,6 +104,8 @@ namespace StationNaming.System
                     target,
                     new ManualSelectNaming(copy)
                 );
+
+                rawNameCandidate.Release();
 
                 var targetName = currentName.Replace(rawCandidateName, updatedName);
                 _nameSystem.SetCustomName(target, targetName);

--- a/System/Cleanup/CleanupSetup.cs
+++ b/System/Cleanup/CleanupSetup.cs
@@ -1,0 +1,31 @@
+﻿// MIT License
+// 
+// Copyright (c) 2024 RollW
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using Colossal.Serialization.Entities;
+using Unity.Entities;
+
+namespace StationNaming.System.Cleanup
+{
+    public struct CleanupSetup : IComponentData, IEmptySerializable
+    {
+    }
+}

--- a/System/Cleanup/CleanupSetupSystem.cs
+++ b/System/Cleanup/CleanupSetupSystem.cs
@@ -1,4 +1,4 @@
-﻿// MIT License
+// MIT License
 //
 // Copyright (c) 2024 RollW
 //
@@ -28,11 +28,6 @@ namespace StationNaming.System.Cleanup
 {
     /// <summary>
     /// System to perform migration setup before cleanup operations.
-    ///
-    /// This system ensures backward compatibility when new Tags (ManualSelectNamingTag
-    /// and NameCandidateTag) are introduced. It migrates existing data by adding
-    /// the appropriate Tags to entities that have the corresponding components
-    /// but lack the Tags.
     ///
     /// The system creates a global singleton entity with CleanupSetup component
     /// to mark that migration is complete. CleanupSystem will only run after
@@ -117,6 +112,7 @@ namespace StationNaming.System.Cleanup
         {
             base.OnCreate();
             Mod.GetLogger().Info("CleanupSetupSystem created.");
+            Enabled = true;
 
             _nameCandidatesForMigrationQuery = GetEntityQuery(new EntityQueryDesc
             {
@@ -149,8 +145,6 @@ namespace StationNaming.System.Cleanup
                     ComponentType.ReadOnly<CleanupSetup>()
                 }
             });
-
-            RequireAnyForUpdate(_nameCandidatesForMigrationQuery, _manualSelectNamingForMigrationQuery);
         }
     }
 }

--- a/System/Cleanup/CleanupSetupSystem.cs
+++ b/System/Cleanup/CleanupSetupSystem.cs
@@ -78,6 +78,8 @@ namespace StationNaming.System.Cleanup
             {
                 Mod.GetLogger().Info($"CleanupSetupSystem: Migrated {count} NameCandidate entities.");
             }
+
+            entities.Dispose();
         }
 
         private void MigrateManualSelectNamings()
@@ -95,6 +97,8 @@ namespace StationNaming.System.Cleanup
             {
                 Mod.GetLogger().Info($"CleanupSetupSystem: Migrated {count} ManualSelectNaming entities.");
             }
+
+            entities.Dispose();
         }
 
         /// <summary>

--- a/System/Cleanup/CleanupSetupSystem.cs
+++ b/System/Cleanup/CleanupSetupSystem.cs
@@ -1,0 +1,156 @@
+﻿// MIT License
+//
+// Copyright (c) 2024 RollW
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using Game;
+using Unity.Collections;
+using Unity.Entities;
+
+namespace StationNaming.System.Cleanup
+{
+    /// <summary>
+    /// System to perform migration setup before cleanup operations.
+    ///
+    /// This system ensures backward compatibility when new Tags (ManualSelectNamingTag
+    /// and NameCandidateTag) are introduced. It migrates existing data by adding
+    /// the appropriate Tags to entities that have the corresponding components
+    /// but lack the Tags.
+    ///
+    /// The system creates a global singleton entity with CleanupSetup component
+    /// to mark that migration is complete. CleanupSystem will only run after
+    /// this setup is done.
+    /// </summary>
+    public partial class CleanupSetupSystem : GameSystemBase
+    {
+        private EntityQuery _nameCandidatesForMigrationQuery;
+        private EntityQuery _manualSelectNamingForMigrationQuery;
+        private EntityQuery _cleanupSetupEntityQuery;
+
+        protected override void OnUpdate()
+        {
+            if (_cleanupSetupEntityQuery.CalculateEntityCount() > 0)
+            {
+                // Migration already done, disable this system
+                Enabled = false;
+                return;
+            }
+
+            PerformMigration();
+            CreateCleanupSetupMarker();
+
+            // Disable this system after migration is complete
+            Enabled = false;
+
+            Mod.GetLogger().Info("CleanupSetupSystem: Migration completed successfully.");
+        }
+
+        private void PerformMigration()
+        {
+            MigrateNameCandidates();
+            MigrateManualSelectNamings();
+        }
+
+        private void MigrateNameCandidates()
+        {
+            var entities = _nameCandidatesForMigrationQuery.ToEntityArray(Allocator.Temp);
+            var count = 0;
+
+            foreach (var entity in entities)
+            {
+                EntityManager.AddComponent<NameCandidateTag>(entity);
+                count++;
+            }
+
+            if (count > 0)
+            {
+                Mod.GetLogger().Info($"CleanupSetupSystem: Migrated {count} NameCandidate entities.");
+            }
+        }
+
+        private void MigrateManualSelectNamings()
+        {
+            var entities = _manualSelectNamingForMigrationQuery.ToEntityArray(Allocator.Temp);
+            var count = 0;
+
+            foreach (var entity in entities)
+            {
+                EntityManager.AddComponent<ManualSelectNamingTag>(entity);
+                count++;
+            }
+
+            if (count > 0)
+            {
+                Mod.GetLogger().Info($"CleanupSetupSystem: Migrated {count} ManualSelectNaming entities.");
+            }
+        }
+
+        /// <summary>
+        /// Creates a global singleton entity with CleanupSetup component
+        /// to mark that migration is complete.
+        /// </summary>
+        private void CreateCleanupSetupMarker()
+        {
+            var setupEntity = EntityManager.CreateEntity();
+            EntityManager.AddComponent<CleanupSetup>(setupEntity);
+            EntityManager.SetName(setupEntity, "StationNaming_CleanupSetup");
+        }
+
+        protected override void OnCreate()
+        {
+            base.OnCreate();
+            Mod.GetLogger().Info("CleanupSetupSystem created.");
+
+            _nameCandidatesForMigrationQuery = GetEntityQuery(new EntityQueryDesc
+            {
+                All = new[]
+                {
+                    ComponentType.ReadOnly<NameCandidate>()
+                },
+                None = new[]
+                {
+                    ComponentType.ReadOnly<NameCandidateTag>()
+                }
+            });
+
+            _manualSelectNamingForMigrationQuery = GetEntityQuery(new EntityQueryDesc
+            {
+                All = new[]
+                {
+                    ComponentType.ReadOnly<ManualSelectNaming>()
+                },
+                None = new[]
+                {
+                    ComponentType.ReadOnly<ManualSelectNamingTag>()
+                }
+            });
+
+            _cleanupSetupEntityQuery = GetEntityQuery(new EntityQueryDesc
+            {
+                All = new[]
+                {
+                    ComponentType.ReadOnly<CleanupSetup>()
+                }
+            });
+
+            RequireAnyForUpdate(_nameCandidatesForMigrationQuery, _manualSelectNamingForMigrationQuery);
+        }
+    }
+}

--- a/System/Cleanup/CleanupSystem.cs
+++ b/System/Cleanup/CleanupSystem.cs
@@ -1,0 +1,107 @@
+﻿// MIT License
+// 
+// Copyright (c) 2024 RollW
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using StationNaming.System.Utils;
+using Unity.Collections;
+using Unity.Entities;
+
+namespace StationNaming.System.Cleanup
+{
+    /// <summary>
+    /// System to clean up unused buffers and components.
+    /// </summary>
+    public partial class CleanupSystem : SystemBase
+    {
+        private EntityQuery _selectedQuery;
+        private EntityQuery _nameCandidatesQuery;
+        private EntityQuery _manualSelectNamingQuery;
+
+
+        protected override void OnUpdate()
+        {
+            var selectedEntities = _selectedQuery.ToEntityArray(Allocator.Temp);
+            foreach (var entity in selectedEntities)
+            {
+                EntityManager.RemoveComponent<NameCandidateTag>(entity);
+            }
+
+            var nameCandidateEntities = _nameCandidatesQuery.ToEntityArray(Allocator.Temp);
+            foreach (var entity in nameCandidateEntities)
+            {
+                SystemUtils.TryCleanRemoveBuffer<NameCandidate>(EntityManager, entity);
+            }
+
+            var manualSelectNamingEntities = _manualSelectNamingQuery.ToEntityArray(Allocator.Temp);
+            foreach (var entity in manualSelectNamingEntities)
+            {
+                SystemUtils.TryCleanRemoveComponent<ManualSelectNaming>(EntityManager, entity);
+            }
+        }
+
+        protected override void OnCreate()
+        {
+            base.OnCreate();
+            Mod.GetLogger().Info("CleanupSystem created.");
+
+            // If an entity was not selected, it shouldn't have the NameCandidateTag
+            _selectedQuery = GetEntityQuery(new EntityQueryDesc
+            {
+                All = new[]
+                {
+                    ComponentType.ReadOnly<NameCandidateTag>()
+                },
+                None = new[]
+                {
+                    ComponentType.ReadOnly<Selected>()
+                }
+            });
+
+            _nameCandidatesQuery = GetEntityQuery(new EntityQueryDesc
+            {
+                All = new[]
+                {
+                    ComponentType.ReadOnly<NameCandidate>(),
+                },
+                None = new[]
+                {
+                    ComponentType.ReadOnly<NameCandidateTag>()
+                }
+            });
+
+            _manualSelectNamingQuery = GetEntityQuery(new EntityQueryDesc
+            {
+                All = new[]
+                {
+                    ComponentType.ReadOnly<ManualSelectNaming>(),
+                },
+                None = new[]
+                {
+                    ComponentType.ReadOnly<ManualSelectNamingTag>()
+                }
+            });
+
+            RequireForUpdate(_manualSelectNamingQuery);
+            RequireForUpdate(_nameCandidatesQuery);
+            RequireForUpdate(_manualSelectNamingQuery);
+        }
+    }
+}

--- a/System/Cleanup/CleanupSystem.cs
+++ b/System/Cleanup/CleanupSystem.cs
@@ -20,6 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using Game;
 using StationNaming.System.Utils;
 using Unity.Collections;
 using Unity.Entities;
@@ -29,15 +30,15 @@ namespace StationNaming.System.Cleanup
     /// <summary>
     /// System to clean up unused buffers and components.
     /// </summary>
-    public partial class CleanupSystem : SystemBase
+    public partial class CleanupSystem : GameSystemBase
     {
         private EntityQuery _selectedQuery;
         private EntityQuery _nameCandidatesQuery;
         private EntityQuery _manualSelectNamingQuery;
 
-
         protected override void OnUpdate()
         {
+            Mod.GetLogger().Info("CleanupSystem started.");
             var selectedEntities = _selectedQuery.ToEntityArray(Allocator.Temp);
             foreach (var entity in selectedEntities)
             {
@@ -47,12 +48,16 @@ namespace StationNaming.System.Cleanup
             var nameCandidateEntities = _nameCandidatesQuery.ToEntityArray(Allocator.Temp);
             foreach (var entity in nameCandidateEntities)
             {
+                Mod.GetLogger().Info($"Entity {entity} has NameCandidate buffer but no NameCandidateTag. Cleaning up.");
                 SystemUtils.TryCleanRemoveBuffer<NameCandidate>(EntityManager, entity);
             }
 
             var manualSelectNamingEntities = _manualSelectNamingQuery.ToEntityArray(Allocator.Temp);
             foreach (var entity in manualSelectNamingEntities)
             {
+                Mod.GetLogger()
+                    .Info(
+                        $"Entity {entity} has ManualSelectNaming component but no ManualSelectNamingTag. Cleaning up.");
                 SystemUtils.TryCleanRemoveComponent<ManualSelectNaming>(EntityManager, entity);
             }
         }
@@ -79,7 +84,7 @@ namespace StationNaming.System.Cleanup
             {
                 All = new[]
                 {
-                    ComponentType.ReadOnly<NameCandidate>(),
+                    ComponentType.ReadOnly<NameCandidate>()
                 },
                 None = new[]
                 {
@@ -91,7 +96,7 @@ namespace StationNaming.System.Cleanup
             {
                 All = new[]
                 {
-                    ComponentType.ReadOnly<ManualSelectNaming>(),
+                    ComponentType.ReadOnly<ManualSelectNaming>()
                 },
                 None = new[]
                 {
@@ -99,7 +104,7 @@ namespace StationNaming.System.Cleanup
                 }
             });
 
-            RequireForUpdate(_manualSelectNamingQuery);
+            RequireForUpdate(_selectedQuery);
             RequireForUpdate(_nameCandidatesQuery);
             RequireForUpdate(_manualSelectNamingQuery);
         }

--- a/System/Cleanup/CleanupSystem.cs
+++ b/System/Cleanup/CleanupSystem.cs
@@ -38,7 +38,6 @@ namespace StationNaming.System.Cleanup
 
         protected override void OnUpdate()
         {
-            Mod.GetLogger().Info("CleanupSystem started.");
             var selectedEntities = _selectedQuery.ToEntityArray(Allocator.Temp);
             foreach (var entity in selectedEntities)
             {
@@ -48,16 +47,12 @@ namespace StationNaming.System.Cleanup
             var nameCandidateEntities = _nameCandidatesQuery.ToEntityArray(Allocator.Temp);
             foreach (var entity in nameCandidateEntities)
             {
-                Mod.GetLogger().Info($"Entity {entity} has NameCandidate buffer but no NameCandidateTag. Cleaning up.");
                 SystemUtils.TryCleanRemoveBuffer<NameCandidate>(EntityManager, entity);
             }
 
             var manualSelectNamingEntities = _manualSelectNamingQuery.ToEntityArray(Allocator.Temp);
             foreach (var entity in manualSelectNamingEntities)
             {
-                Mod.GetLogger()
-                    .Info(
-                        $"Entity {entity} has ManualSelectNaming component but no ManualSelectNamingTag. Cleaning up.");
                 SystemUtils.TryCleanRemoveComponent<ManualSelectNaming>(EntityManager, entity);
             }
         }
@@ -104,9 +99,7 @@ namespace StationNaming.System.Cleanup
                 }
             });
 
-            RequireForUpdate(_selectedQuery);
-            RequireForUpdate(_nameCandidatesQuery);
-            RequireForUpdate(_manualSelectNamingQuery);
+            RequireAnyForUpdate(_selectedQuery, _nameCandidatesQuery, _manualSelectNamingQuery);
         }
     }
 }

--- a/System/Cleanup/CleanupSystem.cs
+++ b/System/Cleanup/CleanupSystem.cs
@@ -51,17 +51,23 @@ namespace StationNaming.System.Cleanup
                 EntityManager.RemoveComponent<NameCandidateTag>(entity);
             }
 
+            selectedEntities.Dispose();
+
             var nameCandidateEntities = _nameCandidatesQuery.ToEntityArray(Allocator.Temp);
             foreach (var entity in nameCandidateEntities)
             {
                 SystemUtils.TryCleanRemoveBuffer<NameCandidate>(EntityManager, entity);
             }
 
+            nameCandidateEntities.Dispose();
+
             var manualSelectNamingEntities = _manualSelectNamingQuery.ToEntityArray(Allocator.Temp);
             foreach (var entity in manualSelectNamingEntities)
             {
                 SystemUtils.TryCleanRemoveComponent<ManualSelectNaming>(EntityManager, entity);
             }
+
+            manualSelectNamingEntities.Dispose();
         }
 
         protected override void OnCreate()

--- a/System/Cleanup/CleanupSystem.cs
+++ b/System/Cleanup/CleanupSystem.cs
@@ -35,9 +35,16 @@ namespace StationNaming.System.Cleanup
         private EntityQuery _selectedQuery;
         private EntityQuery _nameCandidatesQuery;
         private EntityQuery _manualSelectNamingQuery;
+        private EntityQuery _cleanupSetupQuery;
 
         protected override void OnUpdate()
         {
+            if (_cleanupSetupQuery.CalculateEntityCount() == 0)
+            {
+                // Setup not yet complete, skip cleanup
+                return;
+            }
+
             var selectedEntities = _selectedQuery.ToEntityArray(Allocator.Temp);
             foreach (var entity in selectedEntities)
             {
@@ -61,6 +68,15 @@ namespace StationNaming.System.Cleanup
         {
             base.OnCreate();
             Mod.GetLogger().Info("CleanupSystem created.");
+
+            // Query to check if CleanupSetupSystem has completed migration
+            _cleanupSetupQuery = GetEntityQuery(new EntityQueryDesc
+            {
+                All = new[]
+                {
+                    ComponentType.ReadOnly<CleanupSetup>()
+                }
+            });
 
             // If an entity was not selected, it shouldn't have the NameCandidateTag
             _selectedQuery = GetEntityQuery(new EntityQueryDesc

--- a/System/ISelfReleasable.cs
+++ b/System/ISelfReleasable.cs
@@ -1,0 +1,29 @@
+﻿// MIT License
+// 
+// Copyright (c) 2024 RollW
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+namespace StationNaming.System
+{
+    public interface ISelfReleasable
+    {
+        void Release();
+    }
+}

--- a/System/ManualSelectNaming.cs
+++ b/System/ManualSelectNaming.cs
@@ -24,8 +24,8 @@ using Unity.Entities;
 
 namespace StationNaming.System
 {
-    public struct ManualSelectNaming : IComponentData, ISerializable,
-        IEquatable<ManualSelectNaming>
+    public struct ManualSelectNaming : ICleanupComponentData, ISerializable,
+        IEquatable<ManualSelectNaming>, ISelfReleasable
     {
         public NameCandidate SelectedName;
 
@@ -62,6 +62,11 @@ namespace StationNaming.System
         public override string ToString()
         {
             return $"{nameof(SelectedName)}: {SelectedName}";
+        }
+
+        public void Release()
+        {
+            SelectedName.Release();
         }
     }
 }

--- a/System/ManualSelectNamingTag.cs
+++ b/System/ManualSelectNamingTag.cs
@@ -1,0 +1,31 @@
+﻿// MIT License
+// 
+// Copyright (c) 2024 RollW
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using Colossal.Serialization.Entities;
+using Unity.Entities;
+
+namespace StationNaming.System
+{
+    public struct ManualSelectNamingTag : IComponentData, IEmptySerializable
+    {
+    }
+}

--- a/System/NameCandidate.cs
+++ b/System/NameCandidate.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 RollW
+// Copyright (c) 2024 RollW
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -28,16 +28,12 @@ using Unity.Entities;
 
 namespace StationNaming.System
 {
-    public struct NameBlob
-    {
-        public BlobString Value;
-    }
-
     [InternalBufferCapacity(0)]
     public struct NameCandidate : ICleanupBufferElementData,
         ISerializable, IEquatable<NameCandidate>, IJsonWritable, IJsonReadable, ISelfReleasable
     {
-        public FixedString512Bytes Name; // TODO: change to BlobAssetReference<NameBlob> for better memory usage
+        // TODO: use blob asset to reduce memory copy maybe?
+        public FixedString512Bytes Name;
         public NativeList<NameSourceRefer> Refers;
         public Direction Direction;
         public EdgeType EdgeType;
@@ -165,10 +161,14 @@ namespace StationNaming.System
 
         public void Serialize<TWriter>(TWriter writer) where TWriter : IWriter
         {
-            writer.Write(SerialVersion.Version3.ToFormatString());
+            writer.Write(SerialVersion.Version4.ToFormatString());
             writer.Write(Name.ToString());
             writer.Write(Refers.Length);
-            writer.Write(Refers.ToArray(Allocator.Temp));
+            for (var i = 0; i < Refers.Length; i++)
+            {
+                writer.Write(Refers[i]);
+            }
+
             writer.Write((uint)Direction);
             writer.Write((uint)EdgeType);
         }
@@ -178,34 +178,64 @@ namespace StationNaming.System
             try
             {
                 reader.Read(out string version);
-                if (!version.StartsWith(SerialVersionExtensions.Prefix))
+                if (!version.StartsWith(SerialVersionExtensions.Prefix) && !version.StartsWith('\0'))
                 {
                     DeserializeToV2(reader, version);
                     return;
                 }
 
-                reader.Read(out string name);
-                Name = name;
-                reader.Read(out int size);
-                var refers = new NativeArray<NameSourceRefer>(size, Allocator.Temp);
-                reader.Read(refers);
-                Refers = new NativeList<NameSourceRefer>(size, Allocator.Persistent);
-                foreach (var refer in refers)
+                if (SerialVersionExtensions.ParseVersionMark(version, out var parsedVersion) &&
+                    parsedVersion == SerialVersion.Version4)
                 {
-                    Refers.Add(refer);
+                    DeserializeV4(reader);
+                    return;
                 }
 
-                refers.Dispose();
-
-                reader.Read(out uint direction);
-                Direction = (Direction)direction;
-                reader.Read(out uint edgeType);
-                EdgeType = (EdgeType)edgeType;
+                DeserializeV3(reader);
             }
             catch (Exception)
             {
                 SetToInvalid();
             }
+        }
+
+        private void DeserializeV4<TReader>(TReader reader) where TReader : IReader
+        {
+            reader.Read(out string name);
+            Name = name;
+            reader.Read(out int size);
+            Refers = new NativeList<NameSourceRefer>(size, Allocator.Persistent);
+            for (var i = 0; i < size; i++)
+            {
+                reader.Read(out NameSourceRefer refer);
+                Refers.Add(refer);
+            }
+
+            reader.Read(out uint direction);
+            Direction = (Direction)direction;
+            reader.Read(out uint edgeType);
+            EdgeType = (EdgeType)edgeType;
+        }
+
+        private void DeserializeV3<TReader>(TReader reader) where TReader : IReader
+        {
+            reader.Read(out string name);
+            Name = name;
+            reader.Read(out int size);
+            var refers = new NativeArray<NameSourceRefer>(size, Allocator.Temp);
+            reader.Read(refers);
+            Refers = new NativeList<NameSourceRefer>(size, Allocator.Persistent);
+            foreach (var refer in refers)
+            {
+                Refers.Add(refer);
+            }
+
+            refers.Dispose();
+
+            reader.Read(out uint direction);
+            Direction = (Direction)direction;
+            reader.Read(out uint edgeType);
+            EdgeType = (EdgeType)edgeType;
         }
 
         private void DeserializeToV2<TReader>(TReader reader, string name) where TReader : IReader

--- a/System/NameCandidate.cs
+++ b/System/NameCandidate.cs
@@ -32,7 +32,7 @@ namespace StationNaming.System
     public struct NameCandidate : IBufferElementData,
         ISerializable, IEquatable<NameCandidate>, IJsonWritable, IJsonReadable
     {
-        public FixedString512Bytes Name;
+        public FixedString512Bytes Name;// TODO: change to BlobAssetReference<NameBlob> for better memory usage
         public NativeList<NameSourceRefer> Refers;
         public Direction Direction;
         public EdgeType EdgeType;
@@ -336,6 +336,14 @@ namespace StationNaming.System
             return new NameCandidate(
                 name, refers, direction, edgeType
             );
+        }
+
+        public static void Release(ref NameCandidate candidate)
+        {
+            if (candidate.Refers.IsCreated)
+            {
+                candidate.Refers.Dispose();
+            }
         }
     }
 

--- a/System/NameCandidateTag.cs
+++ b/System/NameCandidateTag.cs
@@ -1,0 +1,31 @@
+﻿// MIT License
+// 
+// Copyright (c) 2024 RollW
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using Colossal.Serialization.Entities;
+using Unity.Entities;
+
+namespace StationNaming.System
+{
+    public struct NameCandidateTag : IComponentData, IEmptySerializable
+    {
+    }
+}

--- a/System/StopNameHelper.cs
+++ b/System/StopNameHelper.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 RollW
+// Copyright (c) 2024 RollW
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -152,7 +152,7 @@ namespace StationNaming.System
         {
             var nameCandidates = new HashSet<NameCandidate>();
 
-            var collectEdges = EdgeUtils.CollectIntersections(edge, _entityManager, depth);
+            var collectEdges = EdgeUtils.CollectEdges(_entityManager, edge, depth);
 
             var currentRoad = new RoadEdge(Direction.Init, EdgeType.Same, edge);
             var root = EdgeUtils.GetRootEntityForEdge(edge, _entityManager);

--- a/System/StopNameHelper.cs
+++ b/System/StopNameHelper.cs
@@ -28,6 +28,7 @@ using Game.Objects;
 using Game.Prefabs;
 using Game.UI;
 using StationNaming.Setting;
+using StationNaming.System.Utils;
 using Unity.Entities;
 
 namespace StationNaming.System
@@ -149,7 +150,7 @@ namespace StationNaming.System
         private IEnumerable<NameCandidate> SetCandidatesIfRoad(
             Entity target, Entity edge, int depth, bool includeSelf = false)
         {
-            HashSet<NameCandidate> nameCandidates = new HashSet<NameCandidate>();
+            var nameCandidates = new HashSet<NameCandidate>();
 
             var collectEdges = EdgeUtils.CollectIntersections(edge, _entityManager, depth);
 
@@ -174,7 +175,7 @@ namespace StationNaming.System
 
             if (NameOptions.BuildingName)
             {
-                HashSet<Entity> visitedBuildings = new HashSet<Entity>();
+                var visitedBuildings = new HashSet<Entity>();
                 foreach (var roadEdge in roadEdges)
                 {
                     CollectBuildingNames(
@@ -363,8 +364,11 @@ namespace StationNaming.System
             Entity target
         )
         {
-            var nameCandidates = _entityManager.AddBuffer<NameCandidate>(target);
-            nameCandidates.Clear();
+            SystemUtils.AddComponent<NameCandidateTag>(_entityManager, target);
+            var nameCandidates = SystemUtils.SafeAddBuffer<NameCandidate>(
+                _entityManager,
+                target
+            );
             foreach (var nameCandidate in SortBySource(candidates))
             {
                 var postProcessed = PostProcessNameCandidate(nameCandidate, target);

--- a/System/TransportStationNamingSystem.cs
+++ b/System/TransportStationNamingSystem.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 RollW
+// Copyright (c) 2024 RollW
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/System/UIBindingSystem.cs
+++ b/System/UIBindingSystem.cs
@@ -117,7 +117,7 @@ namespace StationNaming.System
                 EntityManager.HasComponent<Selected>(_selectedEntity))
             {
                 EntityManager.RemoveComponent<Selected>(_selectedEntity);
-                SystemUtils.TryRemoveBuffer<NameCandidate>(EntityManager, _selectedEntity);
+                EntityManager.RemoveComponent<NameCandidateTag>(_selectedEntity);
             }
 
             if (entity != Entity.Null || entity != default)
@@ -144,7 +144,7 @@ namespace StationNaming.System
 
             var buffer = EntityManager.GetBuffer<NameCandidate>(entity);
 
-            List<ManagedNameCandidate> result = new List<ManagedNameCandidate>();
+            var result = new List<ManagedNameCandidate>();
             foreach (var nameCandidate in buffer)
             {
                 result.Add(nameCandidate);
@@ -199,6 +199,7 @@ namespace StationNaming.System
             }
 
             EntityManager.AddComponentData(entity, naming);
+            SystemUtils.AddComponent<ManualSelectNamingTag>(EntityManager, entity);
             _nameSystem.SetCustomName(entity, candidate.Name);
 
             return true;
@@ -227,7 +228,7 @@ namespace StationNaming.System
                 return;
             }
 
-            var last = refers[refers.Count - 1];
+            var last = refers[^1];
             NavigateToEntity(last.Refer);
         }
 
@@ -239,13 +240,6 @@ namespace StationNaming.System
             // TODO:
         }
 
-        private DynamicBuffer<T> GetBuffer<T>(Entity entity) where T : unmanaged, IBufferElementData
-        {
-            return EntityManager.HasBuffer<T>(entity)
-                ? EntityManager.GetBuffer<T>(entity)
-                : EntityManager.AddBuffer<T>(entity);
-        }
-
         private void CheckAndAddCurrent(Entity refer, Entity entity)
         {
             if (refer == Entity.Null)
@@ -253,7 +247,7 @@ namespace StationNaming.System
                 return;
             }
 
-            var buffer = GetBuffer<NamingAssociation>(refer);
+            var buffer = SystemUtils.GetBuffer<NamingAssociation>(EntityManager, refer);
             if (buffer.Length == 0)
             {
                 buffer.Add(new NamingAssociation(entity));

--- a/System/Utils/SystemUtils.cs
+++ b/System/Utils/SystemUtils.cs
@@ -33,6 +33,15 @@ namespace StationNaming.System.Utils
                 : entityManager.AddBuffer<T>(entity);
         }
 
+        public static void AddComponent<T>(EntityManager entityManager, Entity entity)
+            where T : unmanaged, IComponentData
+        {
+            if (!entityManager.HasComponent<T>(entity))
+            {
+                entityManager.AddComponent<T>(entity);
+            }
+        }
+
         public static void TryRemoveBuffer<T>(
             EntityManager entityManager,
             Entity entity) where T : unmanaged, IBufferElementData
@@ -41,9 +50,63 @@ namespace StationNaming.System.Utils
             {
                 return;
             }
+
             var buffer = entityManager.GetBuffer<T>(entity);
             buffer.Clear();
         }
 
+        public static void TryCleanRemoveBuffer<T>(
+            EntityManager entityManager,
+            Entity entity) where T : unmanaged, IBufferElementData, ISelfReleasable
+        {
+            if (!entityManager.HasBuffer<T>(entity))
+            {
+                return;
+            }
+
+            var buffer = entityManager.GetBuffer<T>(entity);
+            for (var i = 0; i < buffer.Length; i++)
+            {
+                var item = buffer[i];
+                item.Release();
+            }
+
+            buffer.Clear();
+        }
+
+        public static void TryCleanRemoveComponent<T>(EntityManager entityManager, Entity entity)
+            where T : unmanaged, IComponentData, ISelfReleasable
+        {
+            if (!entityManager.HasComponent<T>(entity))
+            {
+                return;
+            }
+
+            var component = entityManager.GetComponentData<T>(entity);
+            component.Release();
+            entityManager.RemoveComponent<T>(entity);
+        }
+
+        /// <summary>
+        /// Get or create a buffer, and release all items in it if already exists.
+        /// </summary>
+        public static DynamicBuffer<T> SafeAddBuffer<T>(EntityManager entityManager, Entity target)
+            where T : unmanaged, IBufferElementData, ISelfReleasable
+        {
+            if (!entityManager.HasBuffer<T>(target))
+            {
+                return entityManager.AddBuffer<T>(target);
+            }
+
+            var buffer = entityManager.GetBuffer<T>(target);
+            for (var i = 0; i < buffer.Length; i++)
+            {
+                var item = buffer[i];
+                item.Release();
+            }
+
+            buffer.Clear();
+            return buffer;
+        }
     }
 }

--- a/System/Utils/SystemUtils.cs
+++ b/System/Utils/SystemUtils.cs
@@ -53,6 +53,7 @@ namespace StationNaming.System.Utils
 
             var buffer = entityManager.GetBuffer<T>(entity);
             buffer.Clear();
+            entityManager.RemoveComponent<T>(entity);
         }
 
         public static void TryCleanRemoveBuffer<T>(
@@ -72,6 +73,7 @@ namespace StationNaming.System.Utils
             }
 
             buffer.Clear();
+            entityManager.RemoveComponent<T>(entity);
         }
 
         public static void TryCleanRemoveComponent<T>(EntityManager entityManager, Entity entity)


### PR DESCRIPTION
This pull request introduces a migration and cleanup architecture. The primary focus is on enhancing memory management and stabilizing the component lifecycle through automated ECS cleanup mechanisms.

## Changes

* Introduced `CleanupSetupSystem` and `CleanupSystem` to manage the transition of legacy naming components.
* Implemented logic to identify and purge unused buffers and tags, preventing data persistence issues across versions.
* Utilized `ICleanupComponentData` and `ICleanupBufferElementData` to enable explicit resource disposal and leverage native ECS cleanup flows.